### PR TITLE
Unique output paths

### DIFF
--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -102,11 +102,10 @@ module Rubydoop
       @job.set_input_format_class(format)
     end
 
-    # Sets the output path of the job.
+    # Sets or gets the output path of the job.
     #
     # Calls `setOutputFormatClass` on the Hadoop job and uses the static
     # `setOutputPath` on the output format to set the job's output path.
-    # Or if called without arguments, returns the output path of the job.
     #
     # @see http://hadoop.apache.org/docs/r1.0.3/api/org/apache/hadoop/mapreduce/Job.html#setOutputFormatClass(java.lang.Class) Hadoop's Job#setOutputFormatClass
     #
@@ -114,24 +113,26 @@ module Rubydoop
     # @param [Hash] options
     # @option options [JavaClass] :format The output format to use, defaults to `TextOutputFormat`
     def output(dir=nil, options={})
-      return @output_dir if dir.nil?
-      if dir.is_a?(Hash)
-        options = dir
-        if options[:intermediate]
-          dir = @job.job_name
-        else
-          raise ArgumentError, sprintf('neither dir nor intermediate: true was specified')
+      if dir
+        if dir.is_a?(Hash)
+          options = dir
+          if options[:intermediate]
+            dir = @job.job_name
+          else
+            raise ArgumentError, sprintf('neither dir nor intermediate: true was specified')
+          end
         end
+        dir = sprintf('%s-%010d-%05d', dir, Time.now, rand(1e5)) if options[:intermediate]
+        @output_dir = dir
+        format = options.fetch(:format, :text)
+        unless format.is_a?(Class)
+          class_name = format.to_s.gsub(/^.|_./) {|x| x[-1,1].upcase } + "OutputFormat"
+          format = Hadoop::Mapreduce::Lib::Output.const_get(class_name)
+        end
+        format.set_output_path(@job, Hadoop::Fs::Path.new(@output_dir))
+        @job.set_output_format_class(format)
       end
-      dir = sprintf('%s-%010d-%05d', dir, Time.now, rand(1e5)) if options[:intermediate]
-      @output_dir = dir
-      format = options.fetch(:format, :text)
-      unless format.is_a?(Class)
-        class_name = format.to_s.gsub(/^.|_./) {|x| x[-1,1].upcase } + "OutputFormat"
-        format = Hadoop::Mapreduce::Lib::Output.const_get(class_name)
-      end
-      format.set_output_path(@job, Hadoop::Fs::Path.new(@output_dir))
-      @job.set_output_format_class(format)
+      @output_dir
     end
 
     # Sets a job property.

--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -115,10 +115,16 @@ module Rubydoop
     # @option options [JavaClass] :format The output format to use, defaults to `TextOutputFormat`
     def output(dir=nil, options={})
       return @output_dir if dir.nil?
-      @output_dir = dir
-      if options[:unique]
-        @output_dir += sprintf('-%010d-%05d', Time.now, rand(1e5))
+      if dir.is_a?(Hash)
+        options = dir
+        if options[:intermediate]
+          dir = @job.job_name
+        else
+          raise ArgumentError, sprintf('neither dir nor intermediate: true was specified')
+        end
       end
+      dir = sprintf('%s-%010d-%05d', dir, Time.now, rand(1e5)) if options[:intermediate]
+      @output_dir = dir
       format = options.fetch(:format, :text)
       unless format.is_a?(Class)
         class_name = format.to_s.gsub(/^.|_./) {|x| x[-1,1].upcase } + "OutputFormat"

--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -116,6 +116,9 @@ module Rubydoop
     def output(dir=nil, options={})
       return @output_dir if dir.nil?
       @output_dir = dir
+      if options[:unique]
+        @output_dir += sprintf('-%010d-%05d', Time.now, rand(1e5))
+      end
       format = options.fetch(:format, :text)
       unless format.is_a?(Class)
         class_name = format.to_s.gsub(/^.|_./) {|x| x[-1,1].upcase } + "OutputFormat"

--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -106,19 +106,22 @@ module Rubydoop
     #
     # Calls `setOutputFormatClass` on the Hadoop job and uses the static
     # `setOutputPath` on the output format to set the job's output path.
+    # Or if called without arguments, returns the output path of the job.
     #
     # @see http://hadoop.apache.org/docs/r1.0.3/api/org/apache/hadoop/mapreduce/Job.html#setOutputFormatClass(java.lang.Class) Hadoop's Job#setOutputFormatClass
     #
     # @param [String] dir The output path
     # @param [Hash] options
     # @option options [JavaClass] :format The output format to use, defaults to `TextOutputFormat`
-    def output(dir, options={})
+    def output(dir=nil, options={})
+      return @output_dir if dir.nil?
+      @output_dir = dir
       format = options.fetch(:format, :text)
       unless format.is_a?(Class)
         class_name = format.to_s.gsub(/^.|_./) {|x| x[-1,1].upcase } + "OutputFormat"
         format = Hadoop::Mapreduce::Lib::Output.const_get(class_name)
       end
-      format.set_output_path(@job, Hadoop::Fs::Path.new(dir))
+      format.set_output_path(@job, Hadoop::Fs::Path.new(@output_dir))
       @job.set_output_format_class(format)
     end
 

--- a/spec/rubydoop/job_definition_spec.rb
+++ b/spec/rubydoop/job_definition_spec.rb
@@ -78,31 +78,34 @@ module Rubydoop
         configuration.get('mapreduce.outputformat.class').should == 'org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat'
       end
 
+      it 'returns the output path' do
+        job_definition.output('secret_rubydoop_output_path').should == 'secret_rubydoop_output_path'
+      end
+
       it 'raises ArgumentError if only given options' do
         expect { job_definition.output(format: :text) }.to raise_error(ArgumentError)
       end
 
       context 'with intermediate paths' do
         it 'adds a unique suffix to the path' do
-          job_definition.output('path', intermediate: true)
-          job_definition.output.should =~ /\Apath-\d{10}-\d{5}\Z/
+          job_definition.output('path', intermediate: true).should =~ /\Apath-\d{10}-\d{5}\Z/
         end
 
         it 'defaults to the job name when dir is not set' do
           job.job_name = 'job-name'
-          job_definition.output(intermediate: true)
-          job_definition.output.should =~ /\Ajob-name-\d{10}-\d{5}\Z/
+          job_definition.output(intermediate: true).should =~ /\Ajob-name-\d{10}-\d{5}\Z/
         end
       end
 
       context 'without arguments' do
-        it 'returns the output path' do
-          job_definition.output('secret_rubydoop_output_path')
-          job_definition.output.should == 'secret_rubydoop_output_path'
-        end
-
         it 'returns nil if the output path has not been set' do
           job_definition.output.should be_nil
+        end
+
+        it "doesn't change the output path" do
+          job_definition.output('secret_rubydoop_output_path')
+          job_definition.output
+          job_definition.output.should == 'secret_rubydoop_output_path'
         end
       end
     end

--- a/spec/rubydoop/job_definition_spec.rb
+++ b/spec/rubydoop/job_definition_spec.rb
@@ -78,7 +78,7 @@ module Rubydoop
         configuration.get('mapreduce.outputformat.class').should == 'org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat'
       end
 
-      it 'should raise ArgumentError if only given options' do
+      it 'raises ArgumentError if only given options' do
         expect { job_definition.output(format: :text) }.to raise_error(ArgumentError)
       end
 
@@ -88,7 +88,7 @@ module Rubydoop
           job_definition.output.should =~ /\Apath-\d{10}-\d{5}\Z/
         end
 
-        it 'should default to the job name when dir is not set' do
+        it 'defaults to the job name when dir is not set' do
           job.job_name = 'job-name'
           job_definition.output(intermediate: true)
           job_definition.output.should =~ /\Ajob-name-\d{10}-\d{5}\Z/
@@ -96,12 +96,12 @@ module Rubydoop
       end
 
       context 'without arguments' do
-        it 'should return the output path' do
+        it 'returns the output path' do
           job_definition.output('secret_rubydoop_output_path')
           job_definition.output.should == 'secret_rubydoop_output_path'
         end
 
-        it 'should return nil if the output path has not been set' do
+        it 'returns nil if the output path has not been set' do
           job_definition.output.should be_nil
         end
       end

--- a/spec/rubydoop/job_definition_spec.rb
+++ b/spec/rubydoop/job_definition_spec.rb
@@ -78,6 +78,11 @@ module Rubydoop
         configuration.get('mapreduce.outputformat.class').should == 'org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat'
       end
 
+      it 'should be able to append a unique suffix to the path' do
+        job_definition.output('path', unique: true)
+        job_definition.output.should =~ /\Apath-\d{10}-\d{5}\Z/
+      end
+
       context 'without arguments' do
         it 'should return the output path' do
           job_definition.output('secret_rubydoop_output_path')

--- a/spec/rubydoop/job_definition_spec.rb
+++ b/spec/rubydoop/job_definition_spec.rb
@@ -77,6 +77,17 @@ module Rubydoop
         job_definition.output('path', format: :sequence_file)
         configuration.get('mapreduce.outputformat.class').should == 'org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat'
       end
+
+      context 'without arguments' do
+        it 'should return the output path' do
+          job_definition.output('secret_rubydoop_output_path')
+          job_definition.output.should == 'secret_rubydoop_output_path'
+        end
+
+        it 'should return nil if the output path has not been set' do
+          job_definition.output.should be_nil
+        end
+      end
     end
 
 

--- a/spec/rubydoop/job_definition_spec.rb
+++ b/spec/rubydoop/job_definition_spec.rb
@@ -78,9 +78,21 @@ module Rubydoop
         configuration.get('mapreduce.outputformat.class').should == 'org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat'
       end
 
-      it 'should be able to append a unique suffix to the path' do
-        job_definition.output('path', unique: true)
-        job_definition.output.should =~ /\Apath-\d{10}-\d{5}\Z/
+      it 'should raise ArgumentError if only given options' do
+        expect { job_definition.output(format: :text) }.to raise_error(ArgumentError)
+      end
+
+      context 'with intermediate paths' do
+        it 'adds a unique suffix to the path' do
+          job_definition.output('path', intermediate: true)
+          job_definition.output.should =~ /\Apath-\d{10}-\d{5}\Z/
+        end
+
+        it 'should default to the job name when dir is not set' do
+          job.job_name = 'job-name'
+          job_definition.output(intermediate: true)
+          job_definition.output.should =~ /\Ajob-name-\d{10}-\d{5}\Z/
+        end
       end
 
       context 'without arguments' do


### PR DESCRIPTION
I've managed to have Hadoop jobs fail due to using the same intermediate path for multiple steps on more than one occasion, and have thought a bit about how to avoid it. I'm not sure how much this particular solution actually helps with the problem, but I thought it might at least serve as a decent start for a discussion.

The idea is that you should be able to configure jobs with multiple steps like:
```ruby
Rubydoop.configure do |input_path, output_path|
  first_step = job 'first-step' do
    input input_path
    output intermediate: true
    # rest of definition
  end

  second_step = job 'second-step' do
    input first_step.output
    output intermediate: true
    # rest of definition
  end

  job 'third-step' do
    input second_step.output
    output output_path
    # rest of definition
  end
end
```
The argument handling in `JobDefinition#output` is rather hacky, as it can be used as both a getter and a setter, and with a semi-optional `dir` argument. But I figured that it is better to make it complex than to make using it complex. Then again, I wouldn't mind it not being so hacky.