### PR TITLE
Support running jobs in parallel from the Rubydoop job runner

### DIFF
--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -62,6 +62,14 @@ module Rubydoop
       job.instance_exec(&block)
       job
     end
+
+    def parallel(&block)
+      @context.parallel(&block)
+    end
+
+    def sequence(&block)
+      @context.sequence(&block)
+    end
   end
 
   # Job configuration DSL.
@@ -365,18 +373,71 @@ module Rubydoop
     def initialize(conf, arguments)
       @conf = conf
       @arguments = arguments.to_a
-      @jobs = []
+      @job_stack = [Jobs::Sequence.new]
     end
 
     def create_job(name)
       hadoop_job = Hadoop::Mapreduce::Job.new(@conf, name)
-      @jobs << hadoop_job
+      @job_stack.last.add(hadoop_job)
       hadoop_job
     end
 
     def wait_for_completion(verbose)
-      @jobs.all? do |job|
-        job.wait_for_completion(verbose)
+      @job_stack.first.wait_for_completion(verbose)
+    end
+
+    def parallel
+      push(Jobs::Parallel.new)
+      if block_given?
+        yield
+        pop
+      end
+    end
+
+    def sequence
+      push(Jobs::Sequence.new)
+      if block_given?
+        yield
+        pop
+      end
+    end
+
+    def push(job_list)
+      @job_stack.last.add(job_list)
+      @job_stack.push(job_list)
+    end
+
+    def pop
+      @job_stack.pop
+    end
+
+    class Jobs
+      attr_reader :jobs
+
+      def initialize
+        @jobs = []
+      end
+
+      def add(job)
+        @jobs.push(job)
+      end
+
+      class Sequence < Jobs
+        def wait_for_completion(verbose)
+          @jobs.all? do |job|
+            job.wait_for_completion(verbose)
+          end
+        end
+      end
+
+      class Parallel < Jobs
+        def wait_for_completion(verbose)
+          @jobs.map do |job|
+            Thread.new do
+              job.wait_for_completion(verbose)
+            end
+          end.map!(&:value).all?
+        end
       end
     end
   end

--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -360,7 +360,7 @@ module Rubydoop
 
   # @private
   class Context
-    attr_reader :jobs, :arguments
+    attr_reader :arguments
 
     def initialize(conf, arguments)
       @conf = conf
@@ -372,6 +372,12 @@ module Rubydoop
       hadoop_job = Hadoop::Mapreduce::Job.new(@conf, name)
       @jobs << hadoop_job
       hadoop_job
+    end
+
+    def wait_for_completion(verbose)
+      @jobs.all? do |job|
+        job.wait_for_completion(verbose)
+      end
     end
   end
 end

--- a/spec/integration/hadoop_system_spec.rb
+++ b/spec/integration/hadoop_system_spec.rb
@@ -111,7 +111,7 @@ describe 'Packaging and running a project' do
 
     context 'the word count job' do
       let :words do
-        Hash[File.readlines('data/output/word_count/part-r-00000').map { |line| k, v = line.split(/\s/); [k, v.to_i] }]
+        Hash[File.readlines('data/output/word_count-custom/part-r-00000').map { |line| k, v = line.split(/\s/); [k, v.to_i] }]
       end
 
       it 'runs the mapper and reducer and writes the output in the specified directory' do
@@ -131,6 +131,17 @@ describe 'Packaging and running a project' do
         it "runs the #{type} cleanup method" do
           expect(log).to match(/#{type.upcase}_CLEANUP_COUNT=1$/)
         end
+      end
+    end
+
+    context 'the difference job' do
+      let :differences do
+        Hash[File.readlines('data/output/word_count-diff/part-r-00000').map { |line| line.split(/\s/) }]
+      end
+
+      it 'reflects the lack of Alice doubling combiner for plain' do
+        expect(differences).to include('alice')
+        expect(differences.size).to eq 1
       end
     end
 

--- a/spec/resources/test_project/lib/word_count.rb
+++ b/spec/resources/test_project/lib/word_count.rb
@@ -120,4 +120,26 @@ module WordCount
       ctx.get_counter('Setup and Cleanup', 'COMBINER_CLEANUP_COUNT').increment(1)
     end
   end
+
+  class DiffReducer < Reducer
+    def initialize
+      @output_value = Hadoop::Io::Text.new
+    end
+
+    def setup(ctx)
+      ctx.get_counter('Setup and Cleanup', 'REDUCER_SETUP_COUNT').increment(1)
+    end
+
+    def cleanup(ctx)
+      ctx.get_counter('Setup and Cleanup', 'REDUCER_CLEANUP_COUNT').increment(1)
+    end
+
+    def reduce(key, values, context)
+      values = values.map(&:to_s)
+      if values.size != 2 || values.first != values.last
+        @output_value.set(values.sort.join('/'))
+        context.write(key, @output_value)
+      end
+    end
+  end
 end

--- a/spec/rubydoop/configuration_definition_spec.rb
+++ b/spec/rubydoop/configuration_definition_spec.rb
@@ -1,0 +1,148 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Rubydoop
+  describe ConfigurationDefinition do
+    let :context do
+      Rubydoop::Context.new(config, arguments)
+    end
+
+    let :config do
+      Java::OrgApacheHadoopConf::Configuration.new
+    end
+
+    let :arguments do
+      []
+    end
+
+    before do
+      allow(Hadoop::Mapreduce::Job).to receive(:new) do |config, name|
+        job_factory.create(config, name)
+      end
+    end
+
+    let :job_factory do
+      double(:job_factory)
+    end
+
+    describe 'context wait_for_completion' do
+      context 'with one job' do
+        before do
+          allow(job_factory).to receive(:create).with(config, anything).and_return(job)
+        end
+
+        let! :definition do
+          described_class.new(context) do
+            job 'spec' do
+            end
+          end
+        end
+
+        let :job do
+          double(:job, wait_for_completion: false)
+        end
+
+        it 'delegates to the job' do
+          result = context.wait_for_completion(verbose = true)
+          expect(result).to eq false
+        end
+      end
+
+      context 'with multiple jobs' do
+        let :jobs do
+          [ double('job0'), double('job1'), double('job2') ]
+        end
+
+        before do
+          jobs.each_with_index do |job, index|
+            allow(job).to receive(:wait_for_completion).and_return(true)
+            allow(job_factory).to receive(:create).with(anything, "job#{index}").and_return(job)
+          end
+        end
+
+        context 'in sequence' do
+          let! :definition do
+            described_class.new(context) do
+              job('job0') {}
+              job('job1') {}
+              job('job2') {}
+            end
+          end
+
+          it 'delegates to the jobs' do
+            jobs.each do |job|
+              expect(job).to receive(:wait_for_completion).ordered
+            end
+            context.wait_for_completion(true)
+          end
+
+          it 'returns true when all jobs return true' do
+            result = context.wait_for_completion(true)
+            expect(result).to eq true
+          end
+
+          it 'returns false if any job returns false' do
+            allow(jobs[2]).to receive(:wait_for_completion).and_return(false)
+            result = context.wait_for_completion(true)
+            expect(result).to eq false
+          end
+
+          it 'does not start subsequent jobs' do
+            allow(jobs[1]).to receive(:wait_for_completion).and_return(false)
+            expect(jobs[2]).to_not receive(:wait_for_completion)
+            context.wait_for_completion(true)
+          end
+        end
+
+        context 'in parallel' do
+          let! :definition do
+            described_class.new(context) do
+              parallel do
+                job('job0') {}
+                job('job1') {}
+                job('job2') {}
+              end
+            end
+          end
+
+          it 'delegates to the jobs' do
+            jobs.each do |job|
+              expect(job).to receive(:wait_for_completion)
+            end
+            context.wait_for_completion(true)
+          end
+
+          it 'delegates the jobs in parallel' do
+            latch = Java::JavaUtilConcurrent::CountDownLatch.new(3)
+            jobs.each do |job|
+              allow(job).to receive(:wait_for_completion) do
+                latch.count_down
+                latch.await
+              end
+            end
+            context.wait_for_completion(true)
+            expect(latch.count).to eq 0
+          end
+
+          it 'returns true when all jobs return true' do
+            result = context.wait_for_completion(true)
+            expect(result).to eq true
+          end
+
+          it 'returns false if any job returns false' do
+            allow(jobs[2]).to receive(:wait_for_completion).and_return(false)
+            result = context.wait_for_completion(true)
+            expect(result).to eq false
+          end
+
+          it 'still waits for the completion of all jobs' do
+            allow(jobs[1]).to receive(:wait_for_completion).and_return(false)
+            expect(jobs[2]).to receive(:wait_for_completion)
+            context.wait_for_completion(true)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This introduces `parallel` blocks into the configuration DSL to allow jobs that should be executed in parallel. In addition, this adds support for nested `sequence` blocks inside the `parallel` blocks in order to be able to specify sequences of jobs to be executed in separate swim-lanes.

Unfortunately, I couldn't find any way to listen for completion events for the Hadoop Job class, which means the only simple way to implement support for the above mentioned nesting is by dispatching parallel jobs using threads. The thread overhead should probably be acceptable, though, so lets not worry about that until it becomes a real problem.

While the integration tests contain parallel, they do not really depend on the parallel nature. In practice, they probably also do not run in parallel, as the local Hadoop cluster probably does not execute more than one job at a time.

In order to simplify the implementation of this, I shifted the job runner logic from Java to Ruby.