### PR TITLE
Change the system specs to not depend on RVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 /doc
 /.yardoc
 /.classpath
+/vendor/bundle
+/vendor/test_project-bundle
 .rvmrc
 .ruby-*

--- a/Rakefile
+++ b/Rakefile
@@ -54,14 +54,7 @@ namespace :setup do
 
   task :test_project do
     Dir.chdir('spec/resources/test_project') do
-      command = (<<-END).lines.map(&:strip).join(' && ')
-      rm -f Gemfile.lock
-      rvm $RUBY_VERSION do rvm gemset create rubydoop-test_project
-      rvm $RUBY_VERSION@rubydoop-test_project do gem install bundler
-      rvm $RUBY_VERSION@rubydoop-test_project do bundle install --retry 3
-      END
-      puts command
-      Bundler.clean_system(command)
+      Bundler.clean_system('bundle install --retry 3 --path ../../../vendor/test_project-bundle --binstubs .bundle/bin')
     end
   end
 

--- a/spec/integration/hadoop_system_spec.rb
+++ b/spec/integration/hadoop_system_spec.rb
@@ -16,14 +16,14 @@ end
 describe 'Packaging and running a project' do
   def isolated_run(dir, cmd)
     Dir.chdir(dir) do
-      Bundler.clean_system("rvm $RUBY_VERSION@rubydoop-test_project do #{cmd}")
+      Bundler.clean_system(cmd)
     end
   end
 
   TEST_PROJECT_DIR = File.expand_path('../../resources/test_project', __FILE__)
 
   before :all do
-    isolated_run(TEST_PROJECT_DIR, 'bundle exec rake clean package')
+    isolated_run(TEST_PROJECT_DIR, '.bundle/bin/rake clean package')
   end
 
   around do |example|


### PR DESCRIPTION
Install the integration test setup, and specify a path inside the project directory. Using a path inside spec/resources does not work, however, as one of the gem dependencies bundles their specs, and they
get included in the default spec path.

The nested bundle run installs binstubs so that we can execute rake without the extra bundle exec overhead.