### PR TITLE
Add ConfigurationDefinition#after

### DIFF
--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -65,7 +65,7 @@ module Rubydoop
 
     def wait_for_completion(verbose)
       success = @context.wait_for_completion(verbose)
-      run_result = RunResult.new(success)
+      run_result = RunResult.new(success, @context.jobs)
       @after_callbacks.each { |callback| callback.call(run_result) rescue nil }
       success
     end
@@ -81,9 +81,11 @@ module Rubydoop
   # information about how the run went.
   #
   class RunResult
+    attr_reader :jobs
     # @private
-    def initialize(success)
+    def initialize(success, jobs)
       @success = success
+      @jobs = jobs
     end
 
     def success?
@@ -389,14 +391,17 @@ module Rubydoop
 
   # @private
   class Context
+    attr_reader :jobs
     def initialize(conf)
       @conf = conf
       @job_stack = [Jobs::Sequence.new]
+      @jobs = []
     end
 
     def create_job(name)
       hadoop_job = Hadoop::Mapreduce::Job.new(@conf, name)
       @job_stack.last.add(hadoop_job)
+      @jobs << hadoop_job
       hadoop_job
     end
 

--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -65,12 +65,29 @@ module Rubydoop
 
     def wait_for_completion(verbose)
       success = @context.wait_for_completion(verbose)
-      @after_callbacks.each { |callback| callback.call(success) rescue nil }
+      run_result = RunResult.new(success)
+      @after_callbacks.each { |callback| callback.call(run_result) rescue nil }
       success
     end
 
     def after(&block)
       @after_callbacks << block
+    end
+  end
+
+  # The result of a `Rubydoop.run`
+  #
+  # Instances of this class are yielded in `after`, and contain
+  # information about how the run went.
+  #
+  class RunResult
+    # @private
+    def initialize(success)
+      @success = success
+    end
+
+    def success?
+      @success
     end
   end
 

--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -46,6 +46,7 @@ module Rubydoop
     # @private
     def initialize(context)
       @context = context
+      @after_callbacks = []
     end
 
     def job(name, &block)
@@ -63,7 +64,13 @@ module Rubydoop
     end
 
     def wait_for_completion(verbose)
-      @context.wait_for_completion(verbose)
+      success = @context.wait_for_completion(verbose)
+      @after_callbacks.each { |callback| callback.call(success) }
+      success
+    end
+
+    def after(&block)
+      @after_callbacks << block
     end
   end
 

--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -65,7 +65,7 @@ module Rubydoop
 
     def wait_for_completion(verbose)
       success = @context.wait_for_completion(verbose)
-      @after_callbacks.each { |callback| callback.call(success) }
+      @after_callbacks.each { |callback| callback.call(success) rescue nil }
       success
     end
 

--- a/spec/integration/hadoop_system_spec.rb
+++ b/spec/integration/hadoop_system_spec.rb
@@ -48,6 +48,10 @@ describe 'Packaging and running a project' do
       File.read('data/log')
     end
 
+    it 'runs after-callbacks' do
+      expect(File).to exist('data/output/after-callback')
+    end
+
     context 'the word count job' do
       let :words do
         Hash[File.readlines('data/output/word_count-custom/part-r-00000').map { |line| k, v = line.split(/\s/); [k, v.to_i] }]

--- a/spec/resources/test_project/bin/test_project
+++ b/spec/resources/test_project/bin/test_project
@@ -9,7 +9,7 @@ require 'openssl' # this just asserts that jruby-openssl was packaged correctly
 require 'word_count'
 require 'uniques'
 require 'lazy_output'
-
+require 'fileutils'
 
 Rubydoop.run do |input_path, output_path|
   parallel do
@@ -74,5 +74,9 @@ Rubydoop.run do |input_path, output_path|
 
     output_key Hadoop::Io::Text
     output_value Hadoop::Io::IntWritable
+  end
+
+  after do
+    FileUtils.touch("#{output_path}/after-callback")
   end
 end

--- a/spec/rubydoop/configuration_definition_spec.rb
+++ b/spec/rubydoop/configuration_definition_spec.rb
@@ -36,7 +36,7 @@ module Rubydoop
           described_class.new(context).tap do |definition|
             definition.job('spec') {}
             definition.after { |res| calls << res.success? }
-            definition.after { calls << :second }
+            definition.after { |res| calls << res.jobs }
           end
         end
 
@@ -51,14 +51,14 @@ module Rubydoop
 
         it 'calls #after callbacks with RunResult' do
           definition.wait_for_completion(verbose = true)
-          expect(calls).to eq [false, :second]
+          expect(calls).to eq [false, [job]]
         end
 
         it 'calls all #after callbacks even if one fails' do
           definition.after { raise }
           definition.after { calls << :final }
           definition.wait_for_completion(verbose = true)
-          expect(calls).to eq [false, :second, :final]
+          expect(calls).to eq [false, [job], :final]
         end
       end
 
@@ -81,7 +81,7 @@ module Rubydoop
               definition.job('job1') {}
               definition.job('job2') {}
               definition.after { |res| calls << res.success? }
-              definition.after { calls << :second }
+              definition.after { |res| calls << res.jobs }
             end
           end
 
@@ -99,7 +99,7 @@ module Rubydoop
 
           it 'calls #after callbacks once' do
             definition.wait_for_completion(verbose = true)
-            expect(calls).to eq [true, :second]
+            expect(calls).to eq [true, jobs]
           end
 
           context 'if any job returns false' do
@@ -119,7 +119,7 @@ module Rubydoop
 
             it 'calls #after callbacks once' do
               definition.wait_for_completion(verbose = true)
-              expect(calls).to eq [false, :second]
+              expect(calls).to eq [false, jobs]
             end
           end
         end
@@ -132,7 +132,7 @@ module Rubydoop
                 definition.job('job1') {}
                 definition.job('job2') {}
                 definition.after { |res| calls << res.success? }
-                definition.after { calls << :second }
+                definition.after { |res| calls << res.jobs }
               end
             end
           end
@@ -163,7 +163,7 @@ module Rubydoop
 
           it 'calls #after callbacks once' do
             definition.wait_for_completion(verbose = true)
-            expect(calls).to eq [true, :second]
+            expect(calls).to eq [true, jobs]
           end
 
           context 'if any job returns false' do
@@ -183,7 +183,7 @@ module Rubydoop
 
             it 'calls #after callbacks once' do
               definition.wait_for_completion(verbose = true)
-              expect(calls).to eq [false, :second]
+              expect(calls).to eq [false, jobs]
             end
           end
         end

--- a/spec/rubydoop/configuration_definition_spec.rb
+++ b/spec/rubydoop/configuration_definition_spec.rb
@@ -35,7 +35,7 @@ module Rubydoop
         let! :definition do
           described_class.new(context).tap do |definition|
             definition.job('spec') {}
-            definition.after { |res| calls << res }
+            definition.after { |res| calls << res.success? }
             definition.after { calls << :second }
           end
         end
@@ -49,7 +49,7 @@ module Rubydoop
           expect(result).to eq false
         end
 
-        it 'calls #after callbacks' do
+        it 'calls #after callbacks with RunResult' do
           definition.wait_for_completion(verbose = true)
           expect(calls).to eq [false, :second]
         end
@@ -80,7 +80,7 @@ module Rubydoop
               definition.job('job0') {}
               definition.job('job1') {}
               definition.job('job2') {}
-              definition.after { |res| calls << res }
+              definition.after { |res| calls << res.success? }
               definition.after { calls << :second }
             end
           end
@@ -131,7 +131,7 @@ module Rubydoop
                 definition.job('job0') {}
                 definition.job('job1') {}
                 definition.job('job2') {}
-                definition.after { |res| calls << res }
+                definition.after { |res| calls << res.success? }
                 definition.after { calls << :second }
               end
             end

--- a/spec/rubydoop/configuration_definition_spec.rb
+++ b/spec/rubydoop/configuration_definition_spec.rb
@@ -53,6 +53,13 @@ module Rubydoop
           definition.wait_for_completion(verbose = true)
           expect(calls).to eq [false, :second]
         end
+
+        it 'calls all #after callbacks even if one fails' do
+          definition.after { raise }
+          definition.after { calls << :final }
+          definition.wait_for_completion(verbose = true)
+          expect(calls).to eq [false, :second, :final]
+        end
       end
 
       context 'with multiple jobs' do


### PR DESCRIPTION
As promised, here's a PR suggesting to add `ConfigurationDefinition#after` which would enable users to register callbacks to be run when the all jobs has finished. The callbacks are called with a `RunResult` instance with information about the run, e.g.

``` ruby
Rubydoop.run do |*args|

  # job setup

  after do |result|
    if result.success?
      # job finished successfully
    else
      # job failed
    end
  end
end
```

Taking this further, you could implement similar callbacks for individual jobs and sequences thereof, but I thought I'd start simple.
