### PR TITLE
Fix the commands in README.md for the word count example

### DIFF
--- a/examples/word_count/README.md
+++ b/examples/word_count/README.md
@@ -5,6 +5,5 @@ Run these commands in order to try out the example. You must have Hadoop install
 ```shell
 $ bundle install
 $ rake package
-$ mkdir output
-$ hadoop jar build/word_count.jar word-count -conf conf/hadoop-local.xml ../README.md output
+$ hadoop jar build/word_count.jar word-count -conf conf/hadoop-local.xml README.md output
 ```


### PR DESCRIPTION
The readme for the word count example incorrectly suggests that you should create an output directory, which Hadoop very much wants to do itself. It also suggests using `../README.md` as input, which should probably be either `../../README.md` or just `README.md`. Or am I missing something?

This PR is based on #35.