### PR TITLE
Add support for LazyOutputFormat in the DSL

### DIFF
--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -133,6 +133,9 @@ module Rubydoop
         end
         format.set_output_path(@job, Hadoop::Fs::Path.new(@output_dir))
         @job.set_output_format_class(format)
+        if options[:lazy]
+          Hadoop::Mapreduce::Lib::Output::LazyOutputFormat.set_output_format_class(@job, format)
+        end
       end
       @output_dir
     end

--- a/spec/integration/hadoop_system_spec.rb
+++ b/spec/integration/hadoop_system_spec.rb
@@ -94,5 +94,12 @@ describe 'Packaging and running a project' do
         expect(uniques['e']).to eq 128
       end
     end
+
+    context 'the lazy output job' do
+      it 'produces no output files' do
+        expect(File.exist?('data/output/lazy_output/_SUCCESS')).to be_truthy
+        expect(Dir['data/output/lazy_output/part-r-*']).to be_empty
+      end
+    end
   end
 end

--- a/spec/resources/test_project/bin/test_project
+++ b/spec/resources/test_project/bin/test_project
@@ -8,6 +8,7 @@ require 'openssl' # this just asserts that jruby-openssl was packaged correctly
 
 require 'word_count'
 require 'uniques'
+require 'lazy_output'
 
 
 Rubydoop.run do |input_path, output_path|
@@ -60,6 +61,17 @@ Rubydoop.run do |input_path, output_path|
     grouping_comparator Uniques::GroupingComparator
 
     map_output_value Hadoop::Io::Text
+    output_key Hadoop::Io::Text
+    output_value Hadoop::Io::IntWritable
+  end
+
+  job 'lazy_output' do
+    input input_path
+    output "#{output_path}/lazy_output", lazy: true
+
+    mapper WordCount::Mapper
+    reducer LazyOutput::Reducer
+
     output_key Hadoop::Io::Text
     output_value Hadoop::Io::IntWritable
   end

--- a/spec/resources/test_project/lib/lazy_output.rb
+++ b/spec/resources/test_project/lib/lazy_output.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+module LazyOutput
+  class Reducer
+    def reduce(key, values, context)
+    end
+  end
+end


### PR DESCRIPTION
The `output` DSL method now takes a `:lazy` option, which configures LazyOutputFormat.