### PR TITLE
Update Puck from 1.1.0 to 1.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubydoop (2.0.0.pre0)
-      puck (~> 1.1)
+      puck (~> 1.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -43,7 +43,7 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.3.1)
       spoon (~> 0.0)
-    puck (1.1.0-java)
+    puck (1.2.1-java)
     pusher-client (0.3.1)
       ruby-hmac (~> 0.4.0)
       websocket (~> 1.0.0)

--- a/rubydoop.gemspec
+++ b/rubydoop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'rubydoop'
 
-  s.add_runtime_dependency 'puck', '~> 1.1'
+  s.add_runtime_dependency 'puck', '~> 1.2.1'
 
   s.files         = Dir['lib/**/*.{rb,jar}']
   s.require_paths = %w(lib)


### PR DESCRIPTION
Puck 1.2.0 always calls `Kernel.exit` on task nodes after the setup script has been run, and this ensures that users use a newer version. The problem doesn't exist on 1.1.x, but I see no reason why not to use the latest version when we have to update the version constraint anyhow.