### PR TITLE
Avoid ScriptingContainer.get()/put()

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubydoop (2.0.0.pre0-java)
-      puck (~> 1.1)
+      puck (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -43,7 +43,7 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.3.1)
       spoon (~> 0.0)
-    puck (1.1.0-java)
+    puck (1.2.3-java)
     pusher-client (0.3.1)
       ruby-hmac (~> 0.4.0)
       websocket (~> 1.0.0)

--- a/examples/word_count/README.md
+++ b/examples/word_count/README.md
@@ -5,6 +5,5 @@ Run these commands in order to try out the example. You must have Hadoop install
 ```shell
 $ bundle install
 $ rake package
-$ mkdir output
-$ hadoop jar build/word_count.jar word-count -conf conf/hadoop-local.xml ../README.md output
+$ hadoop jar build/word_count.jar word-count -conf conf/hadoop-local.xml README.md output
 ```

--- a/ext/src/rubydoop/InstanceContainer.java
+++ b/ext/src/rubydoop/InstanceContainer.java
@@ -29,7 +29,7 @@ public class InstanceContainer {
             isLoadPathSetup = Ruby.isGlobalRuntimeReady();
             globalRuntime = new ScriptingContainer(LocalVariableBehavior.PERSISTENT);
             globalRuntime.setCompatVersion(CompatVersion.RUBY1_9);
-            globalRuntime.put("$rubydoop_embedded", true);
+            globalRuntime.runScriptlet("$rubydoop_embedded = true");
         }
         return globalRuntime;
     }
@@ -67,7 +67,7 @@ public class InstanceContainer {
     private static synchronized void setupLoadPath(ScriptingContainer runtime, Configuration conf) {
         if (!isLoadPathSetup) {
             String jobConfigScript = getRequired(conf, JOB_SETUP_SCRIPT_KEY);
-            Object argv = runtime.get("ARGV");
+            Object argv = runtime.runScriptlet("ARGV");
             runtime.callMethod(argv, "unshift", jobConfigScript);
             runtime.callMethod(null, "require", "jar-bootstrap.rb");
             isLoadPathSetup = true;

--- a/lib/rubydoop/job_runner.rb
+++ b/lib/rubydoop/job_runner.rb
@@ -33,8 +33,9 @@ module Rubydoop
 
     def containing_jar
       @containing_jar ||= begin
+        relative_setup_script = @setup_script[/(?<=#{PUCK_ROOT}).+\Z/]
         class_loader = JRuby.runtime.jruby_class_loader
-        if (url = class_loader.get_resources(@setup_script).find { |url| url.protocol == 'jar' })
+        if (url = class_loader.get_resources(relative_setup_script).find { |url| url.protocol == 'jar' })
           path = url.path
           path.slice!(/\Afile:/)
           path = Java::JavaNet::URLDecoder.decode(path, 'UTF-8')

--- a/rubydoop.gemspec
+++ b/rubydoop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'rubydoop'
 
-  s.add_runtime_dependency 'puck', '~> 1.1'
+  s.add_runtime_dependency 'puck', '~> 1.2'
 
   s.files         = Dir['lib/**/*.{rb,jar}']
   s.require_paths = %w(lib)


### PR DESCRIPTION
They are a bit unpredictable in general according to @grddev, and caused `runtime.get("ARGV")` to return `nil` in (at least) JRuby 1.7.23 in particular. This have been tested on EMR using JRuby 1.7.23.