### PR TITLE
Don't submit jobs in parallel

### DIFF
--- a/lib/rubydoop/dsl.rb
+++ b/lib/rubydoop/dsl.rb
@@ -417,6 +417,9 @@ module Rubydoop
       end
 
       class Sequence < Jobs
+        def submit
+        end
+
         def wait_for_completion(verbose)
           @jobs.all? do |job|
             job.wait_for_completion(verbose)
@@ -425,12 +428,16 @@ module Rubydoop
       end
 
       class Parallel < Jobs
+        def submit
+        end
+
         def wait_for_completion(verbose)
+          @jobs.each do |job|
+            job.submit
+          end
           @jobs.map do |job|
-            Thread.new do
-              job.wait_for_completion(verbose)
-            end
-          end.map!(&:value).all?
+            job.wait_for_completion(verbose)
+          end.all?
         end
       end
     end

--- a/spec/rubydoop/configuration_definition_spec.rb
+++ b/spec/rubydoop/configuration_definition_spec.rb
@@ -51,6 +51,7 @@ module Rubydoop
 
         before do
           jobs.each_with_index do |job, index|
+            allow(job).to receive(:submit)
             allow(job).to receive(:wait_for_completion).and_return(true)
             allow(job_factory).to receive(:create).with(anything, "job#{index}").and_return(job)
           end
@@ -109,15 +110,10 @@ module Rubydoop
           end
 
           it 'delegates the jobs in parallel' do
-            latch = Java::JavaUtilConcurrent::CountDownLatch.new(3)
             jobs.each do |job|
-              allow(job).to receive(:wait_for_completion) do
-                latch.count_down
-                latch.await
-              end
+              expect(job).to receive(:submit)
             end
             definition.wait_for_completion(true)
-            expect(latch.count).to eq 0
           end
 
           it 'returns true when all jobs return true' do


### PR DESCRIPTION
Submitting jobs in parallel is not thread safe. There is a "unique number generator" that is used when downloading files to the file cache. Unfortunately this only yields unique numbers for a single job, since each job has it's own LocalDistributedCacheManager.

http://grepcode.com/file/repo1.maven.org/maven2/org.apache.hadoop/hadoop-mapreduce-client-common/2.2.0/org/apache/hadoop/mapred/LocalDistributedCacheManager.java#95

With this change all jobs are submitted sequentially. In a local environment I think it means the jobs are not run in parallel, but in a distributed environment they should.

I was unfortunately not able to run the integration tests, so I don't know if this really works.
